### PR TITLE
Harden cost & context hygiene rules

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -26,7 +26,9 @@ These are always-on global rules. Task-specific procedures live in skills (`.cop
 
 ## Cost & Context Hygiene
 * Checkpoint long efforts. Confirm risky operations.
-* Prefer `view`/`grep`/`glob` over shell commands.
-* Delegate broad research to `explore` sub-agents.
+* Read and search files with `view`/`grep`/`glob`. Never shell out to `cat`/`head`/`tail`/`find`/`grep`/`ls` for reads -- they waste tokens and turns.
+* Delegate broad research and multi-file investigations to `explore` sub-agents; don't grind through inline bash search loops.
+* On long, multi-day sessions, compact context around ~150K tokens. Don't run pinned at the context ceiling.
+* Match the model to the task: a small/cheap model for mechanical work, a heavy model for design and architecture.
 * Never block the main session waiting (e.g. CI/sleeps). Delegate waits to background processes.
 * Summarize status per milestone.


### PR DESCRIPTION
Harden the **Cost & Context Hygiene** rules with four findings from a 30-day Copilot CLI cost review:

- **Ban bash file reads** -- 76% of bash calls were `cat`/`head`/`tail`/`find`/`grep` reads. Replace the soft preference with an explicit `view`/`grep`/`glob`-only rule.
- **Delegate investigations** to `explore` sub-agents instead of inline bash search loops.
- **Compact at ~150K** on multi-day sessions; don't run pinned at the context ceiling.
- **Match model to task** -- small/cheap model for mechanical work, heavy model for design.

All generic; no internal references.
