### PR TITLE
Bootstrap an optional private dotfiles overlay in Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ This is idempotent -- it overwrites the matching files under `~/.copilot/`.
 
 Set this repository as your [dotfiles repository for Codespaces](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles). Codespaces runs `install.sh` automatically when a codespace is created, so your Copilot CLI instructions and skills are available in every codespace.
 
+### Optional private overlay
+
+Codespaces auto-installs dotfiles using the codespace's built-in token, which is scoped to the workspace repo and can't read a personal private repo -- so a private dotfiles repo fails to auto-clone, but this public one clones fine. To layer a private overlay on top of this public base, set two Codespace Secrets and `install.sh` will clone the overlay (with a token that can read it) and run its installer after the public install:
+
+- `DOTFILES_TOKEN` -- a fine-grained PAT with **Contents: read** on the overlay repo.
+- `DOTFILES_REPO` -- the overlay repo as `owner/name`.
+
+With either secret unset, this step is skipped and the public install is all that runs.
+
 ## Skills
 
 | Skill | Purpose |

--- a/install.sh
+++ b/install.sh
@@ -14,3 +14,40 @@ mkdir -p "$HOME/.copilot"
 cp -r "$SRC/.copilot/." "$HOME/.copilot/"
 
 echo "✅ Copilot instructions and skills installed to ~/.copilot/"
+
+# Optional private overlay bootstrap.
+#
+# Codespaces auto-installs dotfiles by cloning this repo with the codespace's
+# built-in token, which is scoped to the workspace repo only -- it cannot read a
+# personal private repo. A public repo like this one therefore clones fine, but a
+# private overlay does not. So, when a maintainer supplies the two secrets below,
+# clone their private overlay here (with a token that *can* read it) and run its
+# installer on top of the public base above.
+#
+# Codespace Secrets (set by the maintainer; unset for everyone else):
+#   DOTFILES_TOKEN  fine-grained PAT with Contents:read on the overlay repo
+#   DOTFILES_REPO   owner/name of the overlay repo (kept in a secret so this
+#                   public script never names a private repo)
+#
+# Absent either secret this block is a no-op, so the public install above is the
+# whole story for anyone else using this repo.
+if [ "${CODESPACES:-}" = "true" ] && [ -n "${DOTFILES_TOKEN:-}" ] && [ -n "${DOTFILES_REPO:-}" ]; then
+  echo "ℹ️  Private dotfiles overlay requested; bootstrapping…"
+  OVERLAY_DIR="$HOME/.dotfiles-internal"
+  rm -rf "$OVERLAY_DIR"
+  # Force non-interactive git so a bad/expired token fails fast instead of
+  # hanging on a credential prompt in the unattended codespace build.
+  if GIT_TERMINAL_PROMPT=0 git clone --depth 1 \
+      "https://x-access-token:${DOTFILES_TOKEN}@github.com/${DOTFILES_REPO}.git" \
+      "$OVERLAY_DIR"; then
+    # Scrub the token from .git/config so it is not left on disk in the codespace.
+    git -C "$OVERLAY_DIR" remote set-url origin "https://github.com/${DOTFILES_REPO}.git"
+    if [ -f "$OVERLAY_DIR/install.sh" ]; then
+      bash "$OVERLAY_DIR/install.sh"
+    else
+      echo "⚠️  overlay repo has no install.sh; skipping overlay install" >&2
+    fi
+  else
+    echo "⚠️  could not clone private overlay repo; continuing with public install only" >&2
+  fi
+fi


### PR DESCRIPTION
## Problem

Pointing Codespaces at a **private** dotfiles repo fails at codespace creation:

```
Cloning into '.../dotfiles'...
fatal: could not read Username for '********': No such device or address
```

The auto-dotfiles clone runs with the codespace's built-in token, which is scoped to the **workspace repo** only. It has no read access to a personal private dotfiles repo, so git gets no credential, falls back to prompting for a username, and dies non-interactively. Only a **public** dotfiles repo auto-clones in this position.

## Fix

Append a Codespaces-gated tail to `install.sh`. When the two secrets below are present, it clones the private overlay repo (with a token that *can* read it) and runs its installer on top of the public base:

- `DOTFILES_TOKEN` -- fine-grained PAT, **Contents: read** on the overlay repo.
- `DOTFILES_REPO` -- overlay repo as `owner/name` (kept in a secret so this public script never names a private repo).

Properties:

- **No-op for everyone else** -- with either secret unset, the block is skipped and the public install is unchanged.
- **Token not left on disk** -- the token is scrubbed from `.git/config` immediately after clone.
- **Graceful degrade** -- a clone failure (bad/expired token) warns and continues with the public-only install rather than aborting.

## Testing

- `bash -n` + `shellcheck`: clean.
- No secrets (`CODESPACES` unset): public copy runs, overlay skipped, exit 0.
- `CODESPACES=true` + bad token + bogus repo: clone fails, warning emitted, public copy still installed, exit 0.
