### PR TITLE
Tighten dash guidance: ban dashes as connective punctuation

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -21,12 +21,12 @@ These are always-on global rules. Task-specific procedures live in skills (`.cop
 
 ## Shell & Markdown
 * Pass markdown with non-ASCII/backticks to `gh` via file/heredoc to avoid escaping errors.
-* Use `--` instead of em-dashes (`—`).
+* Don't use dashes (em-dash, en-dash, `--`, or hyphen) as connective or disjunctive punctuation; use commas, colons, semicolons, parentheses, or separate sentences. Hyphens are fine in compound words and numeric ranges.
 * Always format PR and issue references as clickable links when reporting status.
 
 ## Cost & Context Hygiene
 * Checkpoint long efforts. Confirm risky operations.
-* Read and search files with `view`/`grep`/`glob`. Never shell out to `cat`/`head`/`tail`/`find`/`grep`/`ls` for reads -- they waste tokens and turns.
+* Read and search files with `view`/`grep`/`glob`. Never shell out to `cat`/`head`/`tail`/`find`/`grep`/`ls` for reads; they waste tokens and turns.
 * Delegate broad research and multi-file investigations to `explore` sub-agents; don't grind through inline bash search loops.
 * On long, multi-day sessions, compact context around ~150K tokens. Don't run pinned at the context ceiling.
 * Match the model to the task: a small/cheap model for mechanical work, a heavy model for design and architecture.

--- a/.copilot/skills/create-pr/SKILL.md
+++ b/.copilot/skills/create-pr/SKILL.md
@@ -15,6 +15,6 @@ Use when creating a new pull request.
 
 ## Staging / Dummy PRs
 If the user asks for a "DO NOT MERGE", dummy, throwaway, or staging-validation PR:
-* **Title:** `🚫 DO NOT MERGE -- <short purpose>`
+* **Title:** `🚫 DO NOT MERGE: <short purpose>`
 * **Description:** Start with `## ⚠️ DO NOT MERGE`, explain the purpose, link the source PR, and note it should be closed without merging.
 * Always use a file or heredoc to pass these emojis to the `gh` CLI.

--- a/.copilot/skills/gh-api-markdown/SKILL.md
+++ b/.copilot/skills/gh-api-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-api-markdown
-description: Use when creating, posting, or editing GitHub PR/issue descriptions or comments that contain substantial markdown -- emojis, em-dashes, backticks, tables, links, or multiline/shell-sensitive content -- especially via `gh`, `gh pr/issue`, or `gh api`. Triggers whenever a body must survive shell quoting or a `gh api` call needs a JSON body.
+description: Use when creating, posting, or editing GitHub PR/issue descriptions or comments that contain substantial markdown (emojis, em-dashes, backticks, tables, links, or multiline/shell-sensitive content), especially via `gh`, `gh pr/issue`, or `gh api`. Triggers whenever a body must survive shell quoting or a `gh api` call needs a JSON body.
 ---
 
 # Posting markdown via gh / gh api


### PR DESCRIPTION
## What

Tighten the dash guidance in the global instructions and the two skills that referenced dashes.

- `.copilot/copilot-instructions.md`: replace "Use `--` instead of em-dashes" with a clear rule: don't use dashes (em-dash, en-dash, `--`, or hyphen) as connective or disjunctive punctuation; prefer commas, colons, semicolons, parentheses, or separate sentences. Hyphens stay fine in compound words and numeric ranges. Also drops a stray connective `--` in the Cost & Context Hygiene section.
- `.copilot/skills/create-pr/SKILL.md`: change the DO NOT MERGE title template separator from `--` to `:`.
- `.copilot/skills/gh-api-markdown/SKILL.md`: rewrite the two connective `--` dashes in the description as a parenthetical, kept YAML-safe.

## Why

The old rule actively told the agent to write `--`. The preference now is to avoid dashes as connective or disjunctive punctuation entirely and use ordinary punctuation instead. This updates the rule and makes the instruction files themselves obey it.

## Notes

Frontmatter for both edited skills still parses. No em-dash or en-dash glyphs remain in the edited files.
