### PR TITLE
skills: add gh-api-markdown guidance and manage-prs canvas status rendering

### DIFF
--- a/.copilot/skills/address-pr-review/SKILL.md
+++ b/.copilot/skills/address-pr-review/SKILL.md
@@ -14,5 +14,6 @@ Use when asked to act on a PR's review feedback.
    * Ask me before addressing comments that request scope expansion, architectural changes, or product decisions.
 4. Make the appropriate code changes for each in-scope comment. Commit these as new, distinct commits (do not amend or rebase) so reviewers can easily track your fixes.
 5. Reply to each addressed comment on my behalf, summarizing what was done and noting that you are replying on my behalf.
-6. Resolve a comment only when it is clearly fully addressed and resolving is appropriate. Leave reviewer-owned or open product/architecture threads unresolved, and report why.
-7. Invoke the `validate-changes` skill before pushing.
+6. When posting review replies or PR comments via `gh` / `gh api`, follow the `gh-api-markdown` skill if the body contains substantial markdown, backticks, links, tables, or other multiline / shell-sensitive content.
+7. Resolve a comment only when it is clearly fully addressed and resolving is appropriate. Leave reviewer-owned or open product/architecture threads unresolved, and report why.
+8. Invoke the `validate-changes` skill before pushing.

--- a/.copilot/skills/create-pr/SKILL.md
+++ b/.copilot/skills/create-pr/SKILL.md
@@ -10,8 +10,9 @@ Use when creating a new pull request.
 1. Follow any contribution guidelines (e.g., `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`).
 2. Use the PR template if one exists (e.g., `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE/`) to structure the description.
 3. Invoke the `validate-changes` skill.
-4. Create the PR with a clear title and a description following the template.
-5. Assign me (`Morabbin`) to any PR created for me. If assignment fails, leave it unassigned and report the exact failure. Do not retry with a guessed username.
+4. If the PR body contains substantial markdown or multiline / shell-sensitive content, follow the `gh-api-markdown` skill.
+5. Create the PR with a clear title and a description following the template.
+6. Assign me (`Morabbin`) to any PR created for me. If assignment fails, leave it unassigned and report the exact failure. Do not retry with a guessed username.
 
 ## Staging / Dummy PRs
 If the user asks for a "DO NOT MERGE", dummy, throwaway, or staging-validation PR:

--- a/.copilot/skills/manage-prs/SKILL.md
+++ b/.copilot/skills/manage-prs/SKILL.md
@@ -16,6 +16,7 @@ For each PR being managed:
 5. Invoke the `validate-changes` skill and fix any issues.
 6. Push (`git push`).
 7. Ensure the PR title and description are accurate, current-state-only, with no historical narration.
+8. When reporting PR status, always render or update a PR status table in the inbox widget via `render_widget`; do not rely on inline markdown alone for the table.
 
 When reporting status, mention only current open PRs unless asked about closed or superseded ones.
 
@@ -25,5 +26,6 @@ When asked to manage an epic or coordinate multiple related PRs/issues:
 2. Refresh/sync each PR iteratively using the single-PR steps above.
 3. If missing PRs need bootstrapping, invoke the `create-pr` skill.
 4. If review feedback is in scope, invoke the `address-pr-review` skill.
-5. Update PR/issue bodies in a batched pass.
-6. Publish one consolidated status report covering PR state, linkage state, and blockers.
+5. When batch-updating PR/issue bodies or posting markdown comments, follow the `gh-api-markdown` skill.
+6. Update PR/issue bodies in a batched pass.
+7. Publish one consolidated status report covering PR state, linkage state, and blockers.


### PR DESCRIPTION
Captures live edits to three public skills harvested by the dotfiles sync guard.

## Changes

- **address-pr-review**: Step 6 now references the `gh-api-markdown` skill when posting review replies or PR comments containing substantial markdown, backticks, links, tables, or multiline/shell-sensitive content.
- **create-pr**: Step 4 now references the `gh-api-markdown` skill when the PR body contains substantial markdown or multiline/shell-sensitive content.
- **manage-prs**: Step 8 now instructs the agent to render/update a PR status table via `render_widget` canvas instead of relying on inline markdown. Step 5 now references the `gh-api-markdown` skill for batch body updates.

## Origin

These changes were live-edited in `~/.copilot/skills/` and captured back into the repo by the daily sync guard (capture-dotfiles skill).