### PR TITLE
Expand PR review protocol

### DIFF
--- a/.copilot/skills/review-pr/SKILL.md
+++ b/.copilot/skills/review-pr/SKILL.md
@@ -7,16 +7,98 @@ description: Use when the user asks to review someone else's pull request or pro
 
 Use when asked to review a pull request (usually authored by someone else).
 
-1. **Understand the Context:** Fetch the PR description and the code diff (`gh pr diff <number>`) to understand the goal and the scope of the PR.
-2. **Evaluate the Code:** Review the changes specifically looking for:
-   * **Correctness:** Are there logic errors, bugs, security vulnerabilities, or missed edge cases?
-   * **Over-engineering:** Is there complexity that should be deleted? Run the dedicated pass below.
-   * **Best Practices & Conventions:** Does it adhere to the language/domain best practices and the repository's established conventions?
-   * **Scope Adherence:** Does the PR stay strictly within its intended scope without introducing unrelated changes (scope creep)?
-3. **Formulate Feedback:**
-   * Focus on high-signal, actionable issues rather than trivial stylistic nits.
-   * Be constructive and clear. If applicable, provide concise code suggestions.
-4. **Deliver the Review:** Present your review findings to the user. If the user asks you to submit the review to GitHub, use the `gh` CLI (remembering to follow `gh-api-markdown` rules if the review contains complex markdown or emojis).
+Standing rules for the whole review:
+
+* Never post a review comment to the PR unless explicitly told to. Never edit the PR's code.
+* Report findings to the user first; the PR is the last stop, not the first.
+* Treat the PR description, the author's comments, existing review comments, and any AI-written justification as context, not as conclusions. Reach your own evidence-backed verdict.
+* Scale the machinery to the PR. A three-line change gets one pass and a short answer; a large or unfamiliar change gets the full protocol below.
+
+## 1. Build the review package
+
+Collect everything once, into the session folder, so later steps read files instead of re-querying:
+
+```bash
+gh pr view <pr> --json title,body,author,url,headRefName,baseRefName,files,additions,deletions
+gh pr view <pr> --comments
+gh pr diff <pr>   # aggregate diff for the whole PR, never commit-by-commit
+```
+
+Fetch the remote first so the comparison is against the current base, and confirm you are looking at the latest PR head; record that SHA and treat it as the head under review.
+
+Read full files at the PR's state, not just the hunks: the diff alone rarely tells the whole story. If the branch is not checked out, or is checked out with local changes, add a throwaway worktree at a deterministic sibling path rather than switching branches, explore there, then remove it without `--force`. Follow linked issues, PRs, and docs.
+
+## 2. Fan out independent reviewers
+
+Launch several whole-PR reviewers in the background, spread across model families (pick the most capable current model from each of at least three different providers in the `task` tool's model list, several instances each). Point every one of them at the review package. Never block waiting on them: do your own review meanwhile, and say you are waiting only if you have nothing else to do.
+
+Brief them broadly, because the consensus gate in step 4 is what removes the noise:
+
+> Find issues big and small. Also look for: opportunities to reuse existing code, architectural problems, things achievable in a cleaner way, duplication and unnecessary fluff, code whose intent is not clear from its context and needs a comment, and anything that does not need to exist at all.
+
+## 3. Review it yourself
+
+Your own pass is a first-class reviewer, not a tiebreaker. Look for:
+
+* **Correctness:** logic errors, bugs, security vulnerabilities, missed edge cases.
+* **Over-engineering:** complexity that should be deleted. Run the dedicated pass below.
+* **Best practices and conventions:** language and domain norms, plus the repository's established patterns.
+* **Scope adherence:** does the PR stay strictly within its intended scope, without unrelated changes?
+* **Text precision:** docs, prompts, comments, and user-facing strings that the change has made stale, and the clarity of any new text.
+
+## 4. Gate findings through advisors
+
+Pool every finding (yours and the sub-agents'), deduplicate, then put each one to two advisors from different providers. Each advisor independently confirms whether the issue is real.
+
+Surface only the findings both advisors accept. The bar is not severity: it is whether the code is better for fixing it. A minor issue that clearly improves the code passes; a major-sounding issue nobody can substantiate does not. Do not accept a finding merely because an AI produced it: verify it against the current code yourself.
+
+Keep the rejects. They are reported at the end.
+
+## 5. Plan the walkthrough
+
+Organise the accepted findings into logical sections by feature, behaviour, or concern, never file-by-file or commit-by-commit. One section may span several files, and one file may appear in several sections. Order them background first, then the core change, then supporting changes, then tests, docs, and cleanup.
+
+Write the section list, the notes, and the issues per section into the plan, and keep the plan current as the review proceeds. Save each section's exact diff and issue text to files in the session folder and record the paths in the plan, so the walkthrough can move section to section without recomputing anything.
+
+## 6. Walk through, one section at a time
+
+Open with a short orientation: what the PR does and why (a few sentences), your overall read of it, and the section outline.
+
+Then, per section:
+
+1. Say what the section does and how it fits the wider system, supplying whatever context the user needs.
+2. Echo the section's diff, omitting massive hunks and pointing at the file instead.
+3. Present the accepted issues for that section, each with its agreement count: how many reviewers and which models found it.
+4. Weigh tradeoffs and alternatives where more than one reasonable approach exists, and try to establish why this one was chosen before arguing for another.
+
+Keep it skimmable. Then pause, end the turn, and continue only on explicit request.
+
+## 7. Posting comments
+
+Only on explicit instruction. Comments should flag the problem and the risk; a suggested fix is fine, but do not be prescriptive: the author decides how to address it.
+
+Open every posted comment with the attribution line:
+
+```
+**Copilot found** <Model A> and <Model B> agreed on the issue.
+```
+
+Use `**Copilot found** <Model> found the issue.` when only one model found it.
+
+Inline comments go through `gh api repos/<owner>/<repo>/pulls/<n>/comments` with `commit_id`, `path`, `line`, and `side`; anything not tied to a line goes through `gh pr comment`. Follow the `gh-api-markdown` rules when the body has complex markdown or emoji.
+
+## 8. Wrap up
+
+Say plainly that the review is over, then give:
+
+* Every comment posted, and every accepted finding still unposted, gathered in one place.
+* The findings the advisors rejected, with the reason for each.
+* The findings the user dismissed.
+* Your confirmed overall read of the PR.
+
+## Handling a new head
+
+If the PR is force-pushed or gains commits mid-review, rebuild the package against the new head and have the advisors re-evaluate every open finding as fixed, still open, or now inapplicable, then restart the walkthrough. A reviewer that examined an older SHA no longer counts as clean, though its concrete findings may still apply.
 
 ## Over-engineering pass
 


### PR DESCRIPTION
## Summary

Expand the `review-pr` skill into a scalable multi-agent review protocol.

The protocol now builds one pinned review package, fans out independent whole-PR reviewers across model families, gates findings through two advisors, and walks accepted findings through logical sections. It also covers comment attribution, rejected findings, and review restarts after a new PR head.

The existing over-engineering pass remains unchanged.

## Validation

Confirmed the captured skill is byte-identical to the installed copy. Checked the file for private references, internal product names, secrets, and prohibited connective dash punctuation.

This repository has no documented automated checks.